### PR TITLE
New version with parse_args wrapper

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -23,7 +23,7 @@ setup (
   install_requires=requires,
   
   name = 'ussclicore',
-  version = '1.0.6',
+  version = '1.0.7',
   description='UShareSoft cli core module',
   #long_description='',
   packages = find_packages(),

--- a/src/ussclicore/argumentParser.py
+++ b/src/ussclicore/argumentParser.py
@@ -36,7 +36,7 @@ class ArgumentParser(argparse.ArgumentParser):
 	# Catch the system exit exception and return an empty object if the helper is called
 	def parse_args(self, args):
 		try:
-			super(ArgumentParser,self).parse_args(args)
+			return super(ArgumentParser,self).parse_args(args)
 		except SystemExit as e :
                         return
                         

--- a/src/ussclicore/argumentParser.py
+++ b/src/ussclicore/argumentParser.py
@@ -32,7 +32,14 @@ class ArgumentParser(argparse.ArgumentParser):
 
                 # determine help from format above
                 return formatter.format_help()
-
+	
+	# Catch the system exit exception and return an empty object if the helper is called
+	def parse_args(self, args):
+		try:
+			super(ArgumentParser,self).parse_args(args)
+		except SystemExit as e :
+                        return
+                        
 class CoreArgumentParser(ArgumentParser):
             
         def format_help(self):


### PR DESCRIPTION
Added parse_args wrapper to catch the exception raised by the helper. The parseargs lib is doing a system exit when the helper is called, which is not the behavior we're expecting ... Now the exception is catch and an empty object is returned to the user without exception. The user must verify that the object is not null before retrieving arguments.
